### PR TITLE
Add FORCECONTENTTYPE flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Other behaviour is affected via the following environment variables:
 - **MONGODB**: MongoDB Database URL (default: mongodb://localhost/amqp)
 - **MONGOCOLLECTION**: Database collection to save to (default: messages)
 - **TRANSLATECONTENT**: translate content field (default: true)
+- **FORCECONTENTTYPE**: specify a `content-type` (eg: 'application/json') to override the message content-type for when you dont have control over the AMQP headers on the messages being published. Requires **TRANSLATECONTENT** to be set to `true` in order to work (default: false)
 - **REQUEUEERRORS**: MongoDB errors rejected w/ requeue option (default: false)
 
 **WARNING**: If you set REQUEUEERRORS=true, the message could be redelivered,

--- a/lib/amqp-to-mongo.js
+++ b/lib/amqp-to-mongo.js
@@ -11,6 +11,7 @@ const CONFIG = require('convig').env({
   MONGODB: 'mongodb://localhost/amqp',
   MONGOCOLLECTION: 'messages',
   TRANSLATECONTENT: true,
+  FORCECONTENTTYPE: '',
   REQUEUEERRORS: false
 })
 
@@ -31,6 +32,7 @@ function usage () {
     '  MONGODB: URL of MongoDB Server (default: mongodb://localhost/amqp)',
     '  MONGOCOLLECTION: MongoDB Collection name (default: messages)',
     '  TRANSLATECONTENT: attempt to convert encoding & parse JSON content (default: true)',
+    '  FORCECONTENTTYPE: specify a content-type (eg: "application/json") to override the message content-type for when you dont have control over the AMQP headers on the messages being published. Requires **TRANSLATECONTENT** to be set to "true" in order to work (default: false)' +
     '  REQUEUEERRORS: requeue messages that create an error (default: false)',
     '',
     'This program will keep consuming & saving messages until you interrupt it (CTRL+C)',
@@ -84,6 +86,7 @@ function saver (collection, channel, queueName, opts, msg) {
   }
   // Content Translation
   if (opts.translateContent) {
+    toSave.properties.contentType = (CONFIG.FORCECONTENTTYPE) ? CONFIG.FORCECONTENTTYPE : toSave.properties.contentType
     toSave.content = convertContent(msg.content, toSave.properties)
     finalTranslate(toSave)
   } else {


### PR DESCRIPTION
I came across a situation where I had to save messages from a poorly coded system which I did not have control over.

The system set its `content-type` header to `text/plain` even though the messages were JSON. This made `amqp-to-mongo` store them in mongo as Base64 instead of JSON, which made them impossible to query.

So, I added an option to override the contentType of the message based on an environment variable